### PR TITLE
Do not start bluetooth from init

### DIFF
--- a/rootdir/etc/init.qcom-common.rc
+++ b/rootdir/etc/init.qcom-common.rc
@@ -517,24 +517,7 @@ service time_daemon /system/bin/time_daemon
     group root
 
 on property:vold.decrypt=trigger_restart_framework
-    start config_bluetooth
     start wcnss-service
-
-service config_bluetooth /system/bin/sh /system/etc/init.qcom.bt.sh "onboot"
-    class core
-    user root
-    group bluetooth net_bt_admin qcom_diag radio
-    oneshot
-
-service hciattach /system/bin/sh /system/etc/init.qcom.bt.sh
-    class late_start
-    user bluetooth
-    group bluetooth net_bt_admin qcom_diag radio
-    disabled
-    oneshot
-
-on property:bluetooth.hciattach=true
-    start hciattach
 
 on property:bluetooth.hciattach=false
     setprop bluetooth.status off


### PR DESCRIPTION
Bluetooth is initialised and started from systemd
