### PR TITLE
onyx: enable fluence for voicecall

### DIFF
--- a/onyx.mk
+++ b/onyx.mk
@@ -331,6 +331,11 @@ PRODUCT_PROPERTY_OVERRIDES += \
     debug.qualcomm.sns.daemon=w \
     debug.qualcomm.sns.libsensor1=w
 
+# Fluence settings for voicecall volume control
+PRODUCT_DEFAULT_PROPERTY_OVERRIDES += \
+    ro.qc.sdk.audio.fluencetype=fluence \
+    persist.audio.fluence.mode=endfire
+
 # Call the proprietary setup
 $(call inherit-product-if-exists, vendor/oneplus/onyx/onyx-vendor.mk)
 


### PR DESCRIPTION
intention was to improve sound quality, but seems this change
allows adjusting call volume.

if fluence is enabled for speaker, horribleterrible echo appears.